### PR TITLE
#3 Fix to interpret rotate[xyz] argument values as degrees instead of radians.

### DIFF
--- a/src/obj-magic.cpp
+++ b/src/obj-magic.cpp
@@ -127,9 +127,9 @@ int main(int argc, char* argv[]) {
 	rotangles.y += args.arg(' ', "rotatey", 0.0f);
 	rotangles.z += args.arg(' ', "rotatez", 0.0f);
 	mat4 temprot(1.0f);
-	if (rotangles.x != 0.0f) temprot = rotate(temprot, rotangles.x, vec3(1,0,0));
-	if (rotangles.y != 0.0f) temprot = rotate(temprot, rotangles.y, vec3(0,1,0));
-	if (rotangles.z != 0.0f) temprot = rotate(temprot, rotangles.z, vec3(0,0,1));
+	if (rotangles.x != 0.0f) temprot = rotate(temprot, radians(rotangles.x), vec3(1,0,0));
+	if (rotangles.y != 0.0f) temprot = rotate(temprot, radians(rotangles.y), vec3(0,1,0));
+	if (rotangles.z != 0.0f) temprot = rotate(temprot, radians(rotangles.z), vec3(0,0,1));
 	mat3 rotation(temprot);
 
 	std::ifstream file(infile.c_str(), std::ios::binary);


### PR DESCRIPTION
Easy fix to issue #3. Ran run-tests.sh and pass. Notably, there are no rotate automated tests.